### PR TITLE
Future-proof the library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,7 @@ impl Challonge {
         let response = try!(retry(|| self.client.post(url)
                                         .headers(self.headers.clone())
                                         .body(&body)));
-        let _ = try!(serde_json::from_reader(response));
+        let _: () = try!(serde_json::from_reader(response));
         Ok(())
     }
     


### PR DESCRIPTION
Explicitly specify what type we're deserialising in `create_participant_bulk` to protect against `_` being inferred as having type `!`. See [here](https://github.com/rust-lang/rfcs/pull/1216#issuecomment-230985518) for more info.
