### PR TITLE
Permit empty subdomain in TournamentId.

### DIFF
--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -78,7 +78,11 @@ impl fmt::Display for TournamentId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TournamentId::Url(ref subdomain, ref tournament_url) => {
-                try!(fmt.write_str(&format!("{}-{}", subdomain, tournament_url)));
+                if subdomain.is_empty() {
+                    try!(fmt.write_str(tournament_url));
+                } else {
+                    try!(fmt.write_str(&format!("{}-{}", subdomain, tournament_url)));
+                }
             }
             TournamentId::Id(ref id) => {
                 try!(fmt.write_str(&id.to_string()));


### PR DESCRIPTION
Tournaments on the main site can be referenced with just the path component.

I chose to represent this with an empty string, we could also add another enum variant, or switch the subdomain to Option<String> if you prefer.